### PR TITLE
resolve string type error in GTBlob.m

### DIFF
--- a/ObjectiveGit/GTBlob.m
+++ b/ObjectiveGit/GTBlob.m
@@ -40,7 +40,7 @@
 @implementation GTBlob
 
 - (NSString *)description {
-  return [NSString stringWithFormat:@"<%@: %p> size: %zi, content: %@, data = %@", NSStringFromClass([self class]), self, [self size], [self content], [self data]];
+  return [NSString stringWithFormat:@"<%@: %p> size: %%lli, content: %@, data = %@", NSStringFromClass([self class]), self, [self size], [self content], [self data]];
 }
 
 


### PR DESCRIPTION
macosx: 10.13.4, XCode Version 9.3 (9E145)

reported this error compiling line 43 in GTBlob.m:

Format specifies type 'ssize_t' (aka 'long') but the argument has type 'git_off_t' (aka 'long long')

and suggested this fix:

Replace '%zi' with '%lli'

After applying the change xcode built objective-git successfully